### PR TITLE
Improve the hash function for singed URL`s

### DIFF
--- a/acceptance_test/acceptance_test.go
+++ b/acceptance_test/acceptance_test.go
@@ -80,13 +80,13 @@ var _ = Describe("Accessing the bits-service", func() {
 	})
 
 	Context("through public host", func() {
-		It("returns http.StatusForbidden when accessing package through public host without md5", func() {
+		It("returns http.StatusForbidden when accessing package through public host without hash", func() {
 			Expect(client.Get("https://public.127.0.0.1.nip.io:4443/packages/notexistent")).
 				To(WithTransform(GetStatusCode, Equal(http.StatusForbidden)))
 		})
 
 		Context("After retrieving a signed URL", func() {
-			It("returns http.StatusOK when accessing package through public host with md5", func() {
+			It("returns http.StatusOK when accessing package through public host with hash", func() {
 				request, e := httputil.NewPutRequest("https://internal.127.0.0.1.nip.io:4443/packages/myguid", map[string]map[string]io.Reader{
 					"package": map[string]io.Reader{"somefilename": CreateZip(map[string]string{"somefile": "lalala\n\n"})},
 				})

--- a/api-doc/source/index.html.md
+++ b/api-doc/source/index.html.md
@@ -596,7 +596,7 @@ curl 'https://username:password@internal.example.com/sign/packages/bdf47b84-1349
 ```shell
 HTTP/1.1 200 OK
 
-https://bits-service.example.com/signed/packages/test-package?md5=yBh47LwYRQ4d8SG6mNsL4w&expires=1497357804
+https://bits-service.example.com/signed/packages/test-package?hash=313534313136363839352f7061636b616765732f6d79677569642067656865696de41965ab39e6fc7c04b662edc553cbb39fa62b2c5f4265dd38b241bee95eff40&expires=1541166895&expires=1497357804
 ```
 
 ### HTTP Request
@@ -616,7 +616,7 @@ Internal endpoint only
 > Example signed upload:
 
 ```shell
-curl -X PUT 'https://internal.example.com/signed/packages/bdf47b84-1349-4abd-9561-5004858dfa05?md5=YDjcMjytsnVEzoSxqpiC4A&expires=1492594615' \
+curl -X PUT 'https://internal.example.com/signed/packages/bdf47b84-1349-4abd-9561-5004858dfa05?hash=313534313136363839352f7061636b616765732f6d79677569642067656865696de41965ab39e6fc7c04b662edc553cbb39fa62b2c5f4265dd38b241bee95eff40&expires=1541166895' \
   -F package=@package-file
 ```
 

--- a/blobstores/local/signed_urls.go
+++ b/blobstores/local/signed_urls.go
@@ -14,7 +14,7 @@ type SignatureVerificationMiddleware struct {
 }
 
 func (middleware *SignatureVerificationMiddleware) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
-	if request.URL.Query().Get("md5") == "" {
+	if request.URL.Query().Get("hash") == "" {
 		responseWriter.WriteHeader(403)
 		return
 	}

--- a/blobstores/local/signed_urls_test.go
+++ b/blobstores/local/signed_urls_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Signing URLs", func() {
 		// signing
 		responseBody := handler.Sign("path", "get", mockClock.Now().Add(1*time.Hour))
 
-		Expect(responseBody).To(ContainSubstring("http://example.com/my/path?md5="))
+		Expect(responseBody).To(ContainSubstring("http://example.com/my/path?hash="))
 		Expect(responseBody).To(ContainSubstring("expires"))
 
 		// verifying
@@ -71,7 +71,7 @@ var _ = Describe("Signing URLs", func() {
 		// signing
 		responseBody := handler.Sign("path", "get", mockClock.Now().Add(1*time.Hour))
 
-		Expect(responseBody).To(ContainSubstring("http://example.com/my/path?md5="))
+		Expect(responseBody).To(ContainSubstring("http://example.com/my/path?hash="))
 		Expect(responseBody).To(ContainSubstring("expires"))
 
 		mockClock.Add(longerThanExpirationDuration)


### PR DESCRIPTION
We switch from md5 to hmac+sha256, this prevents attacks e.g. length extension attacks.

[#161674731]