### PR TITLE
Move error to beginning of debug messages

### DIFF
--- a/app_stash_handler.go
+++ b/app_stash_handler.go
@@ -46,13 +46,13 @@ func (handler *AppStashHandler) PostMatches(responseWriter http.ResponseWriter, 
 	var fingerprints []Fingerprint
 	e = json.Unmarshal(body, &fingerprints)
 	if e != nil {
-		logger.From(request).Debugw("Invalid body", "body", string(body), "error", e)
+		logger.From(request).Debugw("Invalid body", "error", e, "body", string(body))
 		responseWriter.WriteHeader(http.StatusUnprocessableEntity)
 		fmt.Fprintf(responseWriter, "Invalid body %s", body)
 		return
 	}
 	if len(fingerprints) == 0 {
-		logger.From(request).Debugw("Empty list", "body", string(body), "error", e)
+		logger.From(request).Debugw("Empty list", "error", e, "body", string(body))
 		responseWriter.WriteHeader(http.StatusUnprocessableEntity)
 		util.FprintDescriptionAsJSON(responseWriter, "The request is semantically invalid: must be a non-empty array.")
 		return


### PR DESCRIPTION
In case there is a huge body, it might happen that the actual error message is cut off (not locally, but e.g. in ELK).
