### PR TITLE
Proper upload stategy to prevent multiple BITS services from uploadin…

### DIFF
--- a/blobstores/azure/azure_blobstore.go
+++ b/blobstores/azure/azure_blobstore.go
@@ -1,84 +1,50 @@
 package azure
 
 import (
+	"context"
+	"crypto/md5"
 	"encoding/base64"
+	"fmt"
 	"io"
-	"io/ioutil"
+	"math"
 	"math/rand"
+	"net/url"
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
-
-	"github.com/Azure/go-autorest/autorest"
-
-	"github.com/Azure/azure-sdk-for-go/storage"
-	"github.com/Azure/go-autorest/autorest/azure"
-
-	"net/http"
-
-	"fmt"
+	"github.com/Azure/azure-pipeline-go/pipeline"
+	a "github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/mattetti/filebuffer"
 
 	bitsgo "github.com/cloudfoundry-incubator/bits-service"
 	"github.com/cloudfoundry-incubator/bits-service/blobstores/validate"
 	"github.com/cloudfoundry-incubator/bits-service/config"
 	"github.com/cloudfoundry-incubator/bits-service/logger"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const (
+	megaByte         = 1 << 20
+	defaultBlockSize = 50 * megaByte
+	maxRetries       = 5
+	retryDelay       = 1 * time.Second
 )
 
 type Blobstore struct {
-	containerName  string
-	client         storage.BlobStorageClient
-	putBlockSize   int64
-	maxListResults uint
 	metricsService bitsgo.MetricsService
+	credential     *a.SharedKeyCredential
+	serviceURL     a.ServiceURL
+	containerURL   a.ContainerURL
+	pipeline       pipeline.Pipeline
+	containerName  string
+	putBlockSize   int
+	maxListResults uint
+	ctx            context.Context
 }
 
 func NewBlobstore(config config.AzureBlobstoreConfig, metricsService bitsgo.MetricsService) *Blobstore {
-	return NewBlobstoreWithDetails(config, 50<<20, 5000, metricsService)
-}
-
-// NetworkErrorRetryingSender is a replacement for the storage.DefaultSender.
-// storage.DefaultSender does not retry on network errors which is rarely what we want in
-// a production system.
-type NetworkErrorRetryingSender struct{}
-
-var retryableStatusCodes = []int{
-	http.StatusRequestTimeout,      // 408
-	http.StatusInternalServerError, // 500
-	http.StatusBadGateway,          // 502
-	http.StatusServiceUnavailable,  // 503
-	http.StatusGatewayTimeout,      // 504
-}
-
-// Send is mostly emulating storage.DefaultSender.Send, so most code was copied.
-// But we use the backoff library for convenience and retry on errors returned from
-// HTTPClient.Do.
-func (sender *NetworkErrorRetryingSender) Send(c *storage.Client, req *http.Request) (*http.Response, error) {
-	rr := autorest.NewRetriableRequest(req)
-	var resp *http.Response
-
-	err := backoff.Retry(func() error {
-		err := rr.Prepare()
-		if err != nil {
-			return backoff.Permanent(err)
-		}
-		resp, err = c.HTTPClient.Do(rr.Request())
-		// We deliberately mark errors *not* as permanent, because an error
-		// here means network connectivity or similar. This is different to the
-		// storage.DefaultSender which stops on any error.
-		if err != nil {
-			return err
-		}
-		if !autorest.ResponseHasStatusCode(resp, retryableStatusCodes...) {
-			return backoff.Permanent(err)
-		}
-		io.Copy(ioutil.Discard, resp.Body)
-		resp.Body.Close()
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 5))
-
-	return resp, err
+	return NewBlobstoreWithDetails(config, defaultBlockSize, 5000, metricsService)
 }
 
 func NewBlobstoreWithDetails(config config.AzureBlobstoreConfig, putBlockSize int64, maxListResults uint, metricsService bitsgo.MetricsService) *Blobstore {
@@ -90,181 +56,272 @@ func NewBlobstoreWithDetails(config config.AzureBlobstoreConfig, putBlockSize in
 		panic("metricsService must not be nil")
 	}
 
-	environment, e := azure.EnvironmentFromName(config.EnvironmentName())
-	if e != nil {
-		logger.Log.Fatalw("Could not get Azure Environment from Name", "error", e, "environment", config.EnvironmentName())
+	if putBlockSize > math.MaxInt32 {
+		logger.Log.Fatalw("putBlockSize must fit into an int32", "putBlockSize", putBlockSize)
+		return nil
 	}
-	client, e := storage.NewBasicClientOnSovereignCloud(config.AccountName, config.AccountKey, environment)
-	if e != nil {
-		logger.Log.Fatalw("Could not instantiate Azure Basic Client", "error", e)
+	if putBlockSize > a.BlockBlobMaxStageBlockBytes {
+		logger.Log.Fatalw("putBlockSize must be equal or less than 100 MB", "putBlockSize", putBlockSize)
+		return nil
 	}
-	client.Sender = &NetworkErrorRetryingSender{}
+	sharedKeyCredential, e := a.NewSharedKeyCredential(config.AccountName, config.AccountKey)
+	if e != nil {
+		logger.Log.Fatalw("Could not instantiate SharedKeyCredential", "error", e)
+	}
+	pipeline := a.NewPipeline(sharedKeyCredential, a.PipelineOptions{
+		Retry: a.RetryOptions{
+			Policy:     a.RetryPolicyExponential,
+			MaxTries:   maxRetries,
+			RetryDelay: retryDelay,
+		}})
+
+	url, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", config.AccountName))
+	serviceURL := a.NewServiceURL(*url, pipeline)
+	containerURL := serviceURL.NewContainerURL(config.ContainerName)
+
 	return &Blobstore{
-		client:         client.GetBlobService(),
-		containerName:  config.ContainerName,
-		putBlockSize:   putBlockSize,
-		maxListResults: maxListResults,
 		metricsService: metricsService,
+		credential:     sharedKeyCredential,
+		pipeline:       pipeline,
+		serviceURL:     serviceURL,
+		containerURL:   containerURL,
+		containerName:  config.ContainerName,
+		putBlockSize:   int(putBlockSize),
+		maxListResults: maxListResults,
+		ctx:            context.Background(),
 	}
 }
 
 func (blobstore *Blobstore) Exists(path string) (bool, error) {
-	exists, e := blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(path).Exists()
-	if e != nil {
-		return false, errors.Wrapf(e, "Failed to check for %v/%v", blobstore.containerName, path)
+	blockBlobURL := blobstore.containerURL.NewBlockBlobURL(path)
+	if _, e := blockBlobURL.GetProperties(blobstore.ctx, a.BlobAccessConditions{}); e != nil {
+		if se, ok := e.(a.StorageError); ok && se.ServiceCode() == a.ServiceCodeBlobNotFound {
+			return false, nil
+		}
+		return false, errors.Wrapf(e, "Failed to check for %s", blockBlobURL)
 	}
-	return exists, nil
+	return true, nil
 }
 
 func (blobstore *Blobstore) Get(path string) (body io.ReadCloser, err error) {
-	logger.Log.Debugw("Get", "bucket", blobstore.containerName, "path", path)
+	blockBlobURL := blobstore.containerURL.NewBlockBlobURL(path)
+	logger.Log.Debugw("Get", "blob", blockBlobURL)
 
-	reader, e := blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(path).Get(nil)
-	if e != nil {
-		return nil, blobstore.handleError(e, "Path %v", path)
+	if response, e := blockBlobURL.Download(blobstore.ctx, 0, a.CountToEnd, a.BlobAccessConditions{}, false); e != nil {
+		return nil, errors.Wrapf(e, "Failed to download for %s", blockBlobURL)
+	} else {
+		return response.Body(a.RetryReaderOptions{}), nil
 	}
-	return reader, nil
 }
 
 func (blobstore *Blobstore) GetOrRedirect(path string) (body io.ReadCloser, redirectLocation string, err error) {
-	signedUrl, e := blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(path).GetSASURI(storage.BlobSASOptions{
-		BlobServiceSASPermissions: storage.BlobServiceSASPermissions{Read: true},
-		SASOptions:                storage.SASOptions{Expiry: time.Now().Add(time.Hour)},
-	})
-	return nil, signedUrl, e
+	defer func() {
+		if e := recover(); e != nil {
+			body = nil
+			redirectLocation = ""
+			err = fmt.Errorf(e.(string))
+		}
+	}()
+
+	expiry := time.Now().UTC().Add(1 * time.Hour)
+	return nil, blobstore.Sign(path, "GET", expiry), nil
 }
 
 func (blobstore *Blobstore) Put(path string, src io.ReadSeeker) error {
-	putRequestID := rand.Int63()
-	l := logger.Log.With("put-request-id", putRequestID)
-	l.Debugw("Put", "bucket", blobstore.containerName, "path", path)
+	//
+	// Upload strategy:
+	// Determine, whether the upload is needed. It's needed if the file is missing, or the size differs, or if the contents differ or we don't know whether contents differ.
+	// If upload is needed, do the following:
+	// It can happen that multiple clients request uploads into the same blob.
+	// To prevent collisions, each client uploads to a unique file first, then copies to the final blob, and deletes the original upload.
+	// The copy operation is protected by a blob lease
+	//
+	var (
+		putRequestID = rand.Int63()
+		l            = logger.Log.With("put-request-id", putRequestID)
+		ctx          = blobstore.ctx
+	)
 
-	pathWithRequestIDSuffix := fmt.Sprintf("%v_%v", path, putRequestID)
-	blob := blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(pathWithRequestIDSuffix)
-
-	e := blob.CreateBlockBlob(nil)
+	exists, blobContentLength, blobContentMD5, e := blobstore.getBlobProps(path)
 	if e != nil {
-		return errors.Wrapf(e, "create block blob failed. container: %v, path: %v, put-request-id: %v", blobstore.containerName, pathWithRequestIDSuffix, putRequestID)
+		return errors.Wrapf(e, "Could not reach Azure blob storage. path: %v, put-request-id: %v", path, putRequestID)
+	}
+	l.Debugw("Put", "bucket", blobstore.containerName, "path", path, "exists", exists, "blobContentLength", blobContentLength, "blobContentMD5", blobContentMD5)
+
+	uploadRequired, sourceContentLength := uploadIsRequired(src, blobContentLength, blobContentMD5)
+	l.Infow("Put", "bucket", blobstore.containerName, "path", path, "uploadRequired", uploadRequired)
+	if !uploadRequired {
+		return nil
 	}
 
-	uncommittedBlocksList := make([]storage.Block, 0)
-	eof := false
-	for i := 0; !eof; i++ {
-		// using information from https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs
-		if i >= 50000 {
-			return errors.Errorf("block blob cannot have more than 50,000 blocks. path: %v, put-request-id: %v", pathWithRequestIDSuffix, putRequestID)
-		}
-		block := storage.Block{
-			ID:     base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%05d", i))),
-			Status: storage.BlockStatusUncommitted,
-		}
-		data := make([]byte, blobstore.putBlockSize)
+	pathWithRequestIDSuffix := fmt.Sprintf("%s_%d", path, putRequestID)
+	l.Debugw("Put", "bucket", blobstore.containerName, "path", path, "pathWithRequestIDSuffix ", pathWithRequestIDSuffix)
+
+	temporaryBlob := blobstore.containerURL.NewBlockBlobURL(pathWithRequestIDSuffix)
+	overallMD5 := md5.New()
+	numberOfBlocks, err := getNumberOfBlocks(sourceContentLength, blobstore.putBlockSize)
+	if err != nil {
+		return errors.Wrapf(err, "PutBlock() failed. path: %v, pathWithRequestIDSuffix : %v, put-request-id: %v", path, pathWithRequestIDSuffix, putRequestID)
+	}
+
+	l.Debugw("Put", "bucket", blobstore.containerName, "path", path, "sourceContentLength", sourceContentLength, "numberOfBlocks", numberOfBlocks, "blobstore.putBlockSize", blobstore.putBlockSize)
+
+	uncommittedBlocksList := make([]string, numberOfBlocks)
+	for i := 0; i < numberOfBlocks; i++ {
+		uncommittedBlocksList[i] = blockIDfromIndex(i)
+	}
+
+	uploadSingleBlock := func(ctx context.Context, blobstore *Blobstore, temporaryBlob a.BlockBlobURL, l *zap.SugaredLogger, bytesToUpload []byte, i int) error {
+		blockID := blockIDfromIndex(i)
+
+		checkSumMD5 := md5.New()
+		checkSumMD5.Write(bytesToUpload)
+		blockMD5bytes := checkSumMD5.Sum(nil)
+		length := len(bytesToUpload)
+
+		t1 := time.Now()
+		body := filebuffer.New(bytesToUpload)
+		response, err := temporaryBlob.StageBlock(ctx, blockID, body, a.LeaseAccessConditions{}, blockMD5bytes)
+		duration := time.Since(t1).Seconds()
+		l.Debugw("Put", "i", i, "azure-upload-bytes", length, "azure-upload-duration", duration, "azure-upload-throughput", fmt.Sprintf("%.2f MB/sec", float64(length)/(duration*megaByte)), "status", response.Status())
+		return err
+	}
+
+	data := make([]byte, blobstore.putBlockSize)
+	for i := 0; i <= numberOfBlocks; i++ {
+		t1 := time.Now()
 		numBytesRead, e := src.Read(data)
-		if e != nil {
-			if e.Error() == "EOF" {
-				eof = true
-			} else {
-				return errors.Wrapf(e, "put block failed. path: %v, put-request-id: %v", pathWithRequestIDSuffix, putRequestID)
-			}
+		duration := time.Since(t1).Seconds()
+		l.Debugw("Put", "i", i, "disk-read-bytes", numBytesRead, "disk-read-duration", duration, "disk-read-throughput", fmt.Sprintf("%.2f MB/s", float64(numBytesRead)/(duration*megaByte)))
+
+		if i == numberOfBlocks && numBytesRead == 0 && e == io.EOF {
+			// now we have reached EOF
+			break
+		} else if e != nil {
+			return errors.Wrapf(e, "put block failed. path: %v, put-request-id: %v", path, putRequestID)
+		} else if i < numberOfBlocks-1 && numBytesRead != blobstore.putBlockSize {
+			// we're not at the last block, but we also didn't get a full block
+			curr, _ := src.Seek(0, io.SeekCurrent)
+			e = fmt.Errorf("The io.Reader.read() operation didn't return a full block of data. Position in stream %d, with %d bytes read, expected %d bytes", curr, numBytesRead, blobstore.putBlockSize)
+			return errors.Wrapf(e, "PutBlock() failed. path: %v, pathWithRequestIDSuffix : %v, put-request-id: %v", path, pathWithRequestIDSuffix, putRequestID)
 		}
-		if numBytesRead == 0 {
-			l.Debugw("Empty read", "block-index", i, "block-id", block.ID, "is-eof", eof)
-			continue
+
+		bytesToUpload := data[:numBytesRead]
+		cloned := append(bytesToUpload[:0:0], bytesToUpload...)
+		overallMD5.Write(cloned)
+		if putBlockErr := uploadSingleBlock(ctx, blobstore, temporaryBlob, l, cloned, i); err != nil {
+			return wrapWithAzureDetails(putBlockErr, fmt.Sprintf("PutBlock() failed. path: %v, pathWithRequestIDSuffix : %v, put-request-id: %v", path, pathWithRequestIDSuffix, putRequestID))
 		}
-		l.Debugw("PutBlock", "block-index", i, "block-id", block.ID, "block-size", numBytesRead, "is-eof", eof)
-		e = backoff.RetryNotify(func() error {
-			return blob.PutBlock(block.ID, data[:numBytesRead], nil)
-		}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 2), func(error, time.Duration) {
-			l.Infow("Retry PutBlock", "block-index", i, "block-id", block.ID, "block-size", numBytesRead, "is-eof", eof)
-			blobstore.metricsService.SendCounterMetric("put-block-retry", 1)
-		})
-		if e != nil {
-			return errors.Wrapf(e, "put block failed. path: %v, put-request-id: %v", pathWithRequestIDSuffix, putRequestID)
-		}
-		uncommittedBlocksList = append(uncommittedBlocksList, block)
-	}
-	l.Debugw("PutBlockList", "uncommitted-block-list", uncommittedBlocksList)
-	e = backoff.RetryNotify(func() error {
-		return blob.PutBlockList(uncommittedBlocksList, nil)
-	}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 2), func(error, time.Duration) {
-		l.Infow("Retry PutBlockList", "uncommitted-block-list", uncommittedBlocksList)
-		blobstore.metricsService.SendCounterMetric("put-block-list-retry", 1)
-	})
-	if e != nil {
-		return errors.Wrapf(e, "put block list failed. path: %v, put-request-id: %v", pathWithRequestIDSuffix, putRequestID)
 	}
 
-	e = backoff.RetryNotify(func() error {
-		return blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(path).Copy(
-			blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(pathWithRequestIDSuffix).GetURL(), nil)
-	}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 100), func(error, time.Duration) {
-		l.Infow("Retry Copy", "src", pathWithRequestIDSuffix, "dest", path)
-		blobstore.metricsService.SendCounterMetric("copy-retry", 1)
-	})
-	if e != nil {
-		return blobstore.handleError(e, "Error while trying to copy src %v to dest %v in bucket %v", pathWithRequestIDSuffix, path, blobstore.containerName)
+	l.Debugw("PutBlockList", "uncommitted-block-list", debugBlockIDAsString(uncommittedBlocksList))
+	if _, putBlockListErr := temporaryBlob.CommitBlockList(blobstore.ctx, uncommittedBlocksList, a.BlobHTTPHeaders{ContentMD5: overallMD5.Sum(nil)}, a.Metadata{}, a.BlobAccessConditions{}); putBlockListErr != nil {
+		return wrapWithAzureDetails(putBlockListErr, fmt.Sprintf("PutBlockList() failed. path: %v, pathWithRequestIDSuffix : %v, put-request-id: %v", path, pathWithRequestIDSuffix, putRequestID))
+	}
+	defer func() {
+		if _, err := temporaryBlob.Delete(ctx, a.DeleteSnapshotsOptionNone, a.BlobAccessConditions{}); err != nil {
+			l.Errorf("Error deleting temporary blob: %s", err)
+			return
+		}
+	}()
+
+	blob := blobstore.containerURL.NewBlockBlobURL(path)
+	var empty [0]byte
+	buf := filebuffer.New(empty[:])
+	if createEmptyResponse, e := blob.Upload(ctx, buf, a.BlobHTTPHeaders{}, a.Metadata{}, a.BlobAccessConditions{}); e != nil {
+		if azse, ok := e.(a.StorageError); ok && azse.ServiceCode() == a.ServiceCodeLeaseIDMissing {
+			return blobstore.handleError(azse, "Another upload is in progress for blob %s/%s (x-ms-request-id %s)", blobstore.containerName, path, createEmptyResponse.RequestID())
+		}
+		return errors.Wrapf(e, "CreateBlockBlob() failed. container: %v, path: %v, put-request-id: %v", blobstore.containerName, path, putRequestID)
 	}
 
-	e = backoff.RetryNotify(func() error {
-		_, e := blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(pathWithRequestIDSuffix).DeleteIfExists(nil)
-		return e
-	}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 2), func(error, time.Duration) {
-		l.Infow("Retry DeleteIfExists", "path", pathWithRequestIDSuffix)
-		blobstore.metricsService.SendCounterMetric("delete-retry", 1)
-	})
-	if e != nil {
-		return blobstore.handleError(e, "Error while trying to delete path %v in bucket %v", pathWithRequestIDSuffix, blobstore.containerName)
+	lease := blobstore.newBlobLease(-1*time.Second, blob) // -1 is infinity
+	if err := lease.acquire(l); err != nil {
+		return err
 	}
+	defer func() {
+		if err := lease.release(); err != nil {
+			l.Errorf("Error during lease handling: %s", err)
+		}
+		l.Debugw("ReleaseLease", "lease-id", lease.LeaseID)
+	}()
+	l.Debugw("AcquireLease", "lease-id", lease.LeaseID)
+
+	if _, copyErr := blob.StartCopyFromURL(
+		ctx, temporaryBlob.URL(), a.Metadata{}, a.ModifiedAccessConditions{},
+		a.BlobAccessConditions{LeaseAccessConditions: a.LeaseAccessConditions{LeaseID: lease.LeaseID}},
+	); copyErr != nil {
+		return wrapWithAzureDetails(copyErr, fmt.Sprintf("Copy() failed. path: %v, pathWithRequestIDSuffix : %v", path, pathWithRequestIDSuffix))
+	}
+	l.Debugw("Copy", "source-blob", temporaryBlob, "destination-blob", blob)
 
 	return nil
 }
 
 func (blobstore *Blobstore) Copy(src, dest string) error {
-	logger.Log.Debugw("Copy in Azure", "container", blobstore.containerName, "src", src, "dest", dest)
-	e := blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(dest).Copy(
-		blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(src).GetURL(), nil)
+	srcURL := blobstore.containerURL.NewBlockBlobURL(src)
+	destURL := blobstore.containerURL.NewBlockBlobURL(dest)
+
+	t1 := time.Now()
+	response, e := destURL.StartCopyFromURL(blobstore.ctx, srcURL.URL(), a.Metadata{}, a.ModifiedAccessConditions{}, a.BlobAccessConditions{})
+	logger.Log.Debugw("Copy", "src", src, "dest", dest, "duration-in-seconds", time.Since(t1).Seconds())
 
 	if e != nil {
-		return blobstore.handleError(e, "Error while trying to copy src %v to dest %v in bucket %v", src, dest, blobstore.containerName)
+		blobstore.handleError(e, "Error while trying to copy src %v to dest %v in bucket %v", src, dest, blobstore.containerName)
 	}
+
+	logger.Log.Debugw("Copy", "container", blobstore.containerName, "src", src, "dest", dest, "copy-id", response.CopyID(), "response-status", response.Status())
 	return nil
 }
 
 func (blobstore *Blobstore) Delete(path string) error {
-	deleted, e := blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(path).DeleteIfExists(nil)
+	blockBlobURL := blobstore.containerURL.NewBlockBlobURL(path)
+
+	t1 := time.Now()
+	response, e := blockBlobURL.Delete(blobstore.ctx, a.DeleteSnapshotsOptionInclude, a.BlobAccessConditions{})
+	logger.Log.Debugw("Delete", "path", path, "duration-in-seconds", time.Since(t1).Seconds())
+
 	if e != nil {
-		return errors.Wrapf(e, "Path %v", path)
+		if se, ok := e.(a.StorageError); ok && se.ServiceCode() == a.ServiceCodeBlobNotFound {
+			// Blob was already deleted
+			return nil
+		}
+		logger.Log.Debugw("Delete", "container", blobstore.containerName, "path", path, "error-code", response.ErrorCode())
+		return errors.Wrapf(e, "Failed to delete %s", blockBlobURL)
+	} else {
+		return nil
 	}
-	if !deleted {
-		return bitsgo.NewNotFoundError()
-	}
-	return nil
 }
 
 func (blobstore *Blobstore) DeleteDir(prefix string) error {
-	deletionErrs := []error{}
-	marker := ""
+	deletionErrs := make([]error, 0)
+	const delimiter = "/"
+	marker := a.Marker{}
+
 	for {
-		response, e := blobstore.client.GetContainerReference(blobstore.containerName).ListBlobs(storage.ListBlobsParameters{
-			Prefix:     prefix,
-			MaxResults: blobstore.maxListResults,
-			Marker:     marker,
-		})
+		response, e := blobstore.containerURL.ListBlobsHierarchySegment(blobstore.ctx, marker, delimiter, a.ListBlobsSegmentOptions{Prefix: prefix})
 		if e != nil {
 			return errors.Wrapf(e, "Prefix %v", prefix)
 		}
-		for _, blob := range response.Blobs {
+
+		for _, blob := range response.Segment.BlobItems {
+			t1 := time.Now()
 			e = blobstore.Delete(blob.Name)
+			logger.Log.Debugw("DeleteDir", "prefix", prefix, "blob-name", blob.Name, "duration-in-seconds", time.Since(t1).Seconds())
+
 			if e != nil {
-				if _, isNotFoundError := e.(*bitsgo.NotFoundError); !isNotFoundError {
+				if _, ok := e.(a.StorageError); !ok {
 					deletionErrs = append(deletionErrs, e)
 				}
 			}
 		}
-		if response.NextMarker == "" {
+
+		marker = response.NextMarker
+		if marker.NotDone() {
+			continue
+		} else {
 			break
 		}
-		marker = response.NextMarker
 	}
 
 	if len(deletionErrs) != 0 {
@@ -273,38 +330,200 @@ func (blobstore *Blobstore) DeleteDir(prefix string) error {
 	return nil
 }
 
-func (blobstore *Blobstore) Sign(resource string, method string, expirationTime time.Time) (signedURL string) {
-	var e error
-	switch strings.ToLower(method) {
-	case "put":
-		signedURL, e = blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(resource).GetSASURI(storage.BlobSASOptions{
-			BlobServiceSASPermissions: storage.BlobServiceSASPermissions{Write: true, Create: true},
-			SASOptions:                storage.SASOptions{Expiry: expirationTime},
-		})
-	case "get":
-		signedURL, e = blobstore.client.GetContainerReference(blobstore.containerName).GetBlobReference(resource).GetSASURI(storage.BlobSASOptions{
-			BlobServiceSASPermissions: storage.BlobServiceSASPermissions{Read: true},
-			SASOptions:                storage.SASOptions{Expiry: expirationTime},
-		})
-	default:
-		panic("The only supported methods are 'put' and 'get'")
+func (blobstore *Blobstore) Sign(path string, method string, expirationTime time.Time) (signedURL string) {
+	blockBlobURL := blobstore.containerURL.NewBlockBlobURL(path)
+
+	permsFromMethod := func(m string) a.BlobSASPermissions {
+		switch strings.ToLower(m) {
+		case "put":
+			return a.BlobSASPermissions{Write: true, Create: true}
+		case "get":
+			return a.BlobSASPermissions{Read: true}
+		default:
+			panic("The only supported methods are 'put' and 'get'")
+		}
 	}
+
+	qp, e := a.BlobSASSignatureValues{
+		Protocol:      a.SASProtocolHTTPS,
+		ExpiryTime:    expirationTime,
+		Permissions:   permsFromMethod(method).String(),
+		ContainerName: blobstore.containerName,
+		BlobName:      path,
+	}.NewSASQueryParameters(blobstore.credential)
+
 	if e != nil {
 		panic(e)
 	}
-	return
+
+	return fmt.Sprintf("%s?%s", blockBlobURL, qp.Encode())
 }
 
 func (blobstore *Blobstore) handleError(e error, context string, args ...interface{}) error {
-	if azse, ok := e.(storage.AzureStorageServiceError); ok && azse.StatusCode == http.StatusNotFound {
-		exists, e := blobstore.client.GetContainerReference(blobstore.containerName).Exists()
-		if e != nil {
-			return errors.Wrapf(e, context, args...)
-		}
-		if !exists {
+	if azse, ok := e.(a.StorageError); ok {
+		if azse.ServiceCode() == a.ServiceCodeContainerNotFound {
 			return errors.Errorf("Container does not exist '%v", blobstore.containerName)
 		}
 		return bitsgo.NewNotFoundError()
 	}
 	return errors.Wrapf(e, context, args...)
+}
+
+func (blobstore *Blobstore) getBlobProps(path string) (exists bool, blobContentLength int64, blobContentMD5 string, err error) {
+	blockBlobURL := blobstore.containerURL.NewBlockBlobURL(path)
+	props, err := blockBlobURL.GetProperties(blobstore.ctx, a.BlobAccessConditions{})
+	if err != nil {
+		exists = false
+		blobContentLength = -1
+		blobContentMD5 = ""
+
+		if azse, ok := err.(a.StorageError); ok && azse.ServiceCode() == a.ServiceCodeBlobNotFound {
+			err = nil
+		}
+		return
+	}
+	exists = true
+	blobContentLength = props.ContentLength()
+	blobContentMD5 = base64.StdEncoding.EncodeToString(props.ContentMD5())
+	return
+}
+
+func uploadIsRequired(src io.ReadSeeker, blobContentLength int64, blobContentMD5 string) (uploadRequired bool, sourceContentLength int64) {
+	// Check if upload is actually required
+	sourceContentLength, err := src.Seek(0, io.SeekEnd)
+	defer src.Seek(0, io.SeekStart)
+	if err != nil {
+		// if the blob can't be found -> upload
+		uploadRequired = true
+		return
+	}
+	if sourceContentLength != blobContentLength {
+		// if the length differs -> upload
+		uploadRequired = true
+		return
+	}
+	if blobContentMD5 == "" {
+		// if we cannot check the MD5 -> upload
+		uploadRequired = true
+		return
+	}
+	src.Seek(0, io.SeekStart)
+	hash := md5.New()
+	io.Copy(hash, src)
+	localResourceMD5 := base64.StdEncoding.EncodeToString(hash.Sum(nil))
+
+	// if the MD5 differs -> upload
+	uploadRequired = blobContentMD5 != localResourceMD5
+	return
+}
+
+func getNumberOfBlocks(inputLength int64, blockSize int) (int, error) {
+	fullyFilledBlocks := int(inputLength / int64(blockSize))
+	hasPartiallyFilledBlock := (inputLength % int64(blockSize)) > 0
+	var numberOfBlocks int
+	if hasPartiallyFilledBlock {
+		numberOfBlocks = fullyFilledBlocks + 1
+	} else {
+		numberOfBlocks = fullyFilledBlocks
+	}
+	if numberOfBlocks > a.BlockBlobMaxBlocks {
+		return -1, errors.Errorf("BlockBlob cannot have more than %d blocks. File size %v bytes, block size %d", a.BlockBlobMaxBlocks, inputLength, blockSize)
+	}
+	return numberOfBlocks, nil
+}
+
+func blockIDfromIndex(i int) string {
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%05d", i)))
+}
+
+func wrapWithAzureDetails(e error, message string) error {
+	if e == nil {
+		return nil
+	}
+	// if azse, ok := e.(a.StorageError); ok {
+	// 	return errors.Wrapf(e, "%s x-ms-request-id: %s", message, azse.RequestID)
+	// }
+	return errors.Wrapf(e, "%s", message)
+}
+
+func debugBlockIDAsString(l []string) string {
+	length := len(l)
+	if length == 0 {
+		return fmt.Sprintf("[] (%d blocks overall)", length)
+	} else if length == 1 {
+		return fmt.Sprintf("[%v] (%d blocks overall)", l[0], length)
+	} else if length == 2 {
+		return fmt.Sprintf("[%v, %v] (%d blocks overall)", l[0], l[length-1], length)
+	} else {
+		return fmt.Sprintf("[%v, ..., %v] (%d blocks overall)", l[0], l[length-1], length)
+	}
+}
+
+type azureBlobLease struct {
+	Duration     time.Duration
+	Blobstore    *Blobstore
+	Blob         a.BlockBlobURL
+	LeaseID      string
+	DoneChannel  chan bool
+	ErrorChannel chan error
+}
+
+func (blobstore *Blobstore) newBlobLease(duration time.Duration, blob a.BlockBlobURL) *azureBlobLease {
+	return &azureBlobLease{
+		DoneChannel:  make(chan bool, 1),
+		ErrorChannel: make(chan error, 1),
+		Duration:     duration,
+		Blobstore:    blobstore,
+		Blob:         blob,
+		LeaseID:      "",
+	}
+}
+
+func (l *azureBlobLease) acquire(logger *zap.SugaredLogger) error {
+	leaseDurationInSeconds := int32(l.Duration.Seconds())
+	proposedID := ""
+	response, err := l.Blob.AcquireLease(l.Blobstore.ctx, proposedID, leaseDurationInSeconds, a.ModifiedAccessConditions{})
+	if err != nil {
+		if azse, ok := err.(a.StorageError); ok && azse.ServiceCode() == a.ServiceCodeLeaseIDMissing {
+			return l.Blobstore.handleError(azse, "Another upload is in progress for blob %s", l.Blob)
+		}
+		return err
+	}
+
+	l.LeaseID = response.LeaseID()
+	go func(l *azureBlobLease) {
+		if l.Duration.Seconds() == -1 {
+			// for an infinite lease, wait for the DoneChannel and release it
+			_ = <-l.DoneChannel
+			_, releaseErr := l.Blob.ReleaseLease(l.Blobstore.ctx, l.LeaseID, a.ModifiedAccessConditions{})
+			l.ErrorChannel <- releaseErr
+			return
+		} else {
+			for {
+				select {
+				case done := <-l.DoneChannel:
+					if !done {
+					}
+					_, releaseErr := l.Blob.ReleaseLease(l.Blobstore.ctx, l.LeaseID, a.ModifiedAccessConditions{})
+					l.ErrorChannel <- releaseErr
+					return
+				case <-time.After(l.Duration):
+					_, renewLeaseErr := l.Blob.RenewLease(l.Blobstore.ctx, l.LeaseID, a.ModifiedAccessConditions{})
+					if renewLeaseErr != nil {
+						logger.Errorf("Error during RenewLease: %s", renewLeaseErr)
+					}
+				}
+			}
+		}
+	}(l)
+
+	return nil
+}
+
+func (l *azureBlobLease) release() error {
+	if l.LeaseID == "" {
+		return fmt.Errorf("Lease was not properly created")
+	}
+	l.DoneChannel <- true
+	return <-l.ErrorChannel
 }

--- a/glide.lock
+++ b/glide.lock
@@ -61,21 +61,16 @@ imports:
   - private/protocol/xml/xmlutil
   - service/s3
   - service/sts
-- name: github.com/Azure/azure-sdk-for-go
-  version: 580a14a5a4b8830727fda07d73bd6f69e64b14f8
+- name: github.com/Azure/azure-pipeline-go
+  version: 76b57228f36adfbb7e6990ba1347a7fbbf3043da
   subpackages:
-  - storage
-  - version
-- name: github.com/Azure/go-autorest
-  version: 4e5fffdf007df29ed0862f9e01fafabf4396e851
+  - pipeline
+- name: github.com/Azure/azure-storage-blob-go
+  version: 457680cc0804810f6d02958481e0ffdda51d5c60
   subpackages:
-  - autorest
-  - autorest/adal
-  - autorest/azure
-  - autorest/date
-  - logger
-  - tracing
-  - version
+  - azblob
+- name: github.com/mattetti/filebuffer
+  version: 3a1e8e5a6548ea21cce597660d0c0dcc8c77a520
 - name: github.com/benbjohnson/clock
   version: 7dc76406b6d3c05b5f71a86293cbcf3c4ea03b19
 - name: github.com/cenkalti/backoff

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,7 +24,10 @@ import:
 - package: cloud.google.com/go
   subpackages:
   - storage
-- package: github.com/Azure/azure-sdk-for-go
+- package: github.com/Azure/azure-storage-blob-go
+  subpackages:
+  - azblob
+- package: github.com/mattetti/filebuffer
 - package: github.com/ncw/swift
 - package: github.com/cenkalti/backoff
 - package: github.com/aliyun/aliyun-oss-go-sdk


### PR DESCRIPTION
…g to the same blob, and updated Azure/Go SDK.

- When uploading a blob, the upload now contains a Content-MD5.
- Uploads are only done if necessary, i.e.
  - if the blob doesn't yet exist, or
  - if it has a different size, or
  - if it has the same size, but due to lack of a Content-MD5 can't be tracked whether the existing blob has the same contents, or
  - if it has a ContentMD5, but the local / to-be-uploaded contents differ from the existing blob.
- When uploading to a certain location, we first upload to a temporary name, and then we copy within the storage account to the proper location.
  - This copy operation is protected by an Azure blob lease, to prevent two concurrent copy operations.
- Each block blob upload is also protected against accidental modifications with a MD5
- The SDK has been upgraded from a really old one, to the current Azure Go SDK (which supports context.Context) to allow subsequent parallelization of uploads