### PR TITLE
Set user 2000:2000 in image manifest

### DIFF
--- a/oci_registry/registry.go
+++ b/oci_registry/registry.go
@@ -26,6 +26,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	vcapUid int = 2000
+	vcapGid int = 2000
+)
+
 type ImageHandler struct {
 	ImageManager *BitsImageManager
 }
@@ -224,8 +229,8 @@ func preFixDroplet(cfDroplet io.Reader, ociDroplet io.Writer) {
 
 		hdr.Name = filepath.Join("/home/vcap", hdr.Name)
 		hdr.Mode = 0777
-		hdr.Uname = "vcap"
-		hdr.Gname = "vcap"
+		hdr.Uid = vcapUid
+		hdr.Gid = vcapGid
 		e = layer.WriteHeader(hdr)
 		util.PanicOnError(errors.WithStack(e))
 		_, e = io.Copy(layer, t)
@@ -260,7 +265,7 @@ func (b *BitsImageManager) GetBlob(name string, digest string) io.ReadCloser {
 func (b *BitsImageManager) configMetadata(rootfsDigest string, dropletDigest string) []byte {
 	config, e := json.Marshal(map[string]interface{}{
 		"config": map[string]interface{}{
-			"user": "vcap",
+			"user": fmt.Sprintf("%d:%d", vcapUid, vcapGid),
 		},
 		"rootfs": map[string]interface{}{
 			"type": "layers",

--- a/oci_registry/registry_test.go
+++ b/oci_registry/registry_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Registry", func() {
 				"manifests": [
 				  {
 					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-					"digest": "sha256:47a9ce51d74ebb495e919c1efd156685f7d6f16bfaccd99fb42078c037503c7b",
+					"digest": "sha256:a633dfab15a2f56b3e5d05971fb5e17e91cbec5fbdc192c6873e059da75c387b",
 					"size": 582,
 					"platform": {
 					  "architecture": "amd64",
@@ -104,15 +104,15 @@ var _ = Describe("Registry", func() {
 				]
 			  }`))
 
-			res, e = doGetRequest("/v2/irrelevant-image-name/manifests/sha256:47a9ce51d74ebb495e919c1efd156685f7d6f16bfaccd99fb42078c037503c7b")
+			res, e = doGetRequest("/v2/irrelevant-image-name/manifests/sha256:a633dfab15a2f56b3e5d05971fb5e17e91cbec5fbdc192c6873e059da75c387b")
 			Expect(res.StatusCode, e).To(Equal(http.StatusOK))
 			Expect(ioutil.ReadAll(res.Body)).To(MatchJSON(`{
 				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
 				"schemaVersion": 2,
 				"config": {
 					"mediaType": "application/vnd.docker.container.image.v1+json",
-					"digest": "sha256:17b61ff749fc15f044f0657485654c36b322844320d93535d19a9080f82ff821",
-					"size": 214
+					"digest": "sha256:63460d0ba1dd1ec2ad8889a8dc46382209c0929c8f6421e51de715648fd337c3",
+					"size": 219
 				},
 				"layers": [
 					{
@@ -128,11 +128,11 @@ var _ = Describe("Registry", func() {
 				]
 			}`))
 
-			res, e = doGetRequest("/v2/irrelevant-image-name/blobs/sha256:17b61ff749fc15f044f0657485654c36b322844320d93535d19a9080f82ff821")
+			res, e = doGetRequest("/v2/irrelevant-image-name/blobs/sha256:63460d0ba1dd1ec2ad8889a8dc46382209c0929c8f6421e51de715648fd337c3")
 			Expect(e).NotTo(HaveOccurred())
 			Expect(ioutil.ReadAll(res.Body)).To(MatchJSON(`{
 				"config": {
-				  "user": "vcap"
+				  "user": "2000:2000"
 				},
 				"rootfs": {
 				  "diff_ids": [
@@ -163,8 +163,8 @@ var _ = Describe("Registry", func() {
 				Expect(e).NotTo(HaveOccurred())
 				Expect(header.Name).To(HavePrefix("/home/vcap"))
 				Expect(header.Mode).To(Equal(int64(0777)))
-				Expect(header.Uname).To(Equal("vcap"))
-				Expect(header.Gname).To(Equal("vcap"))
+				Expect(header.Uid).To(Equal(2000))
+				Expect(header.Gid).To(Equal(2000))
 			}
 		})
 


### PR DESCRIPTION
Previously the non-numeric user `vcap` was being used which doe snot
work on k8s. This change is needed so that eirini can stop setting
`runAsUser 2000` when desireing apps.

More info: https://github.com/cloudfoundry-incubator/eirini/pull/116

P.S. We have just replaced the hardcoded `vcap` user with its numeric equvalent `2000` in this PR, which is not worse than it used to be, but maybe a more robust fix would be to start reading the user from the `eirinifs` image manifest.